### PR TITLE
Sudo and Scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ Install-AITool -Name Gemini, Aider
 Install-AITool -Name All
 ```
 
+### Installation Scope (Linux)
+
+By default, tools install to user-local directories (`CurrentUser` scope) without requiring elevated privileges. On Linux, you can optionally install system-wide:
+
+```powershell
+# User-local installation (default, no sudo required)
+Install-AITool -Name Aider -Scope CurrentUser
+
+# System-wide installation (requires sudo on Linux)
+Install-AITool -Name Gemini -Scope LocalMachine
+```
+
+When using `-Scope LocalMachine` on Linux:
+- You'll be prompted for your sudo password if needed
+- Prerequisites (Node.js, pipx) are installed via apt-get
+- Tools are available to all users on the system
+
+On macOS, Homebrew handles installations without requiring sudo, so both scopes work without elevated privileges.
+
 ## Set your default
 
 ```powershell

--- a/private/Invoke-SudoCommand.ps1
+++ b/private/Invoke-SudoCommand.ps1
@@ -1,0 +1,135 @@
+function Invoke-SudoCommand {
+    <#
+    .SYNOPSIS
+        Executes a command with sudo if required on Linux.
+
+    .DESCRIPTION
+        Wraps command execution to handle sudo requirements on Linux.
+        On macOS and Windows, runs commands directly without modification.
+
+        For Linux with LocalMachine scope:
+        - Validates sudo access is available before execution
+        - Prepends sudo to commands if not running as root
+        - Provides clear error messages if sudo access fails
+
+    .PARAMETER Command
+        The command to execute.
+
+    .PARAMETER Scope
+        The installation scope. Affects whether sudo is needed.
+
+    .PARAMETER Description
+        A description of what the command does, for error messages.
+
+    .OUTPUTS
+        [PSCustomObject] With properties:
+        - Success: [bool] Whether the command succeeded
+        - ExitCode: [int] The exit code
+        - Output: [string] Combined stdout/stderr
+        - Command: [string] The actual command that was run
+
+    .EXAMPLE
+        Invoke-SudoCommand -Command 'apt-get update' -Scope LocalMachine -Description 'updating package lists'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Command,
+
+        [Parameter()]
+        [ValidateSet('CurrentUser', 'LocalMachine')]
+        [string]$Scope = 'CurrentUser',
+
+        [Parameter()]
+        [string]$Description = 'executing command'
+    )
+
+    $os = Get-OperatingSystem
+    $needsSudo = Test-SudoRequired -Scope $Scope
+    $actualCommand = $Command
+
+    # On Linux with LocalMachine scope, we need to handle sudo
+    if ($needsSudo) {
+        Write-PSFMessage -Level Verbose -Message "Sudo required for: $Description"
+
+        # First, validate that sudo access is available
+        # Use sudo -n (non-interactive) to check if we have passwordless sudo
+        # or if sudo credentials are cached
+        $sudoCheck = & bash -c 'sudo -n true 2>/dev/null; echo $?' 2>$null
+        $hasSudoAccess = ($sudoCheck -eq '0')
+
+        if (-not $hasSudoAccess) {
+            # Try to prompt for sudo password by running sudo -v
+            # This will cache credentials for subsequent commands
+            Write-PSFMessage -Level Host -Message "Elevated privileges required for $Description. You may be prompted for your password."
+
+            # Run sudo -v to prompt for password and cache credentials
+            # This needs to be interactive, so we use Start-Process with UseShellExecute
+            $validateResult = & bash -c 'sudo -v 2>&1; echo "EXIT:$?"'
+            $exitLine = $validateResult | Select-Object -Last 1
+            $sudoValidated = $exitLine -eq 'EXIT:0'
+
+            if (-not $sudoValidated) {
+                return [PSCustomObject]@{
+                    Success  = $false
+                    ExitCode = 1
+                    Output   = "Failed to obtain sudo privileges. Please ensure you have sudo access and try again."
+                    Command  = $Command
+                }
+            }
+        }
+
+        # Prepend sudo to the command if it doesn't already have it
+        if ($Command -notmatch '^\s*sudo\s') {
+            $actualCommand = "sudo $Command"
+        }
+    }
+
+    Write-PSFMessage -Level Verbose -Message "Executing: $actualCommand"
+
+    try {
+        if ($os -eq 'Windows') {
+            # On Windows, use cmd.exe
+            $psi = New-Object System.Diagnostics.ProcessStartInfo
+            $psi.FileName = 'cmd.exe'
+            $psi.Arguments = "/c `"$actualCommand`""
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.UseShellExecute = $false
+            $psi.CreateNoWindow = $true
+        } else {
+            # On Linux/macOS, use bash
+            $psi = New-Object System.Diagnostics.ProcessStartInfo
+            $psi.FileName = '/bin/bash'
+            $psi.Arguments = "-c `"$actualCommand`""
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.UseShellExecute = $false
+            $psi.CreateNoWindow = $true
+        }
+
+        $process = New-Object System.Diagnostics.Process
+        $process.StartInfo = $psi
+        $process.Start() | Out-Null
+
+        $stdout = $process.StandardOutput.ReadToEnd()
+        $stderr = $process.StandardError.ReadToEnd()
+        $process.WaitForExit()
+
+        $output = @($stdout, $stderr) | Where-Object { $_ } | Join-String -Separator "`n"
+
+        return [PSCustomObject]@{
+            Success  = ($process.ExitCode -eq 0)
+            ExitCode = $process.ExitCode
+            Output   = $output
+            Command  = $actualCommand
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Success  = $false
+            ExitCode = -1
+            Output   = $_.Exception.Message
+            Command  = $actualCommand
+        }
+    }
+}

--- a/private/Test-SudoRequired.ps1
+++ b/private/Test-SudoRequired.ps1
@@ -1,0 +1,61 @@
+function Test-SudoRequired {
+    <#
+    .SYNOPSIS
+        Determines if sudo is required for a command on the current platform.
+
+    .DESCRIPTION
+        Checks whether the current user needs sudo/elevated privileges to run
+        system-level commands. On Linux, checks if running as root. On macOS,
+        most operations (Homebrew, npm, pipx) do NOT require sudo.
+
+    .PARAMETER Scope
+        The installation scope. LocalMachine typically requires elevated privileges on Linux.
+
+    .OUTPUTS
+        [bool] True if sudo is required, False otherwise.
+
+    .NOTES
+        - Linux with LocalMachine scope: Requires sudo for apt-get and system-wide installations
+        - macOS: Homebrew and most package managers do NOT require sudo
+        - Windows: Not applicable (uses different elevation model)
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [ValidateSet('CurrentUser', 'LocalMachine')]
+        [string]$Scope = 'CurrentUser'
+    )
+
+    $os = Get-OperatingSystem
+
+    # Windows doesn't use sudo
+    if ($os -eq 'Windows') {
+        return $false
+    }
+
+    # macOS: Homebrew and modern package managers don't need sudo
+    # They install to /usr/local or /opt/homebrew which are user-writable
+    if ($os -eq 'MacOS') {
+        return $false
+    }
+
+    # Linux: Only LocalMachine scope needs sudo
+    if ($os -eq 'Linux') {
+        if ($Scope -eq 'CurrentUser') {
+            return $false
+        }
+
+        # LocalMachine scope - check if already root
+        $userId = & id -u 2>$null
+        if ($userId -eq '0') {
+            # Already running as root
+            return $false
+        }
+
+        # Need sudo for LocalMachine on Linux
+        return $true
+    }
+
+    return $false
+}


### PR DESCRIPTION
This pull request adds robust support for user-local and system-wide installation and uninstallation scopes on Linux, including proper sudo handling. It introduces helper functions to determine when sudo is needed and to prompt for credentials when required. The documentation and tests have been updated to reflect these changes.

**Scope-aware installation and uninstallation with sudo handling:**

* Added `Invoke-SudoCommand` (`private/Invoke-SudoCommand.ps1`) to execute commands with sudo when required, including credential validation and clear error messages.
* Added `Test-SudoRequired` (`private/Test-SudoRequired.ps1`) to determine if sudo is needed based on OS and installation scope.
* Updated `Install-AITool` to use `Invoke-SudoCommand` for system-wide (`LocalMachine`) pipx installs and improved Node.js installation logic to handle sudo and error reporting more gracefully. [[1]](diffhunk://#diff-f9a72099e1963b0b6adfccbb9f356fd42ee68968758e19a25e601e2c9e585a08L339-R354) [[2]](diffhunk://#diff-f9a72099e1963b0b6adfccbb9f356fd42ee68968758e19a25e601e2c9e585a08L422-R432) [[3]](diffhunk://#diff-f9a72099e1963b0b6adfccbb9f356fd42ee68968758e19a25e601e2c9e585a08L447-R453)
* Updated `Uninstall-AITool` to support the `Scope` parameter and use `Invoke-SudoCommand` for system-wide uninstalls on Linux. [[1]](diffhunk://#diff-7294911a29c887745c0c918ae84fbbc07d82770ec9d8cf5827db6d3418b815b4R24-R27) [[2]](diffhunk://#diff-7294911a29c887745c0c918ae84fbbc07d82770ec9d8cf5827db6d3418b815b4L35-R43) [[3]](diffhunk://#diff-7294911a29c887745c0c918ae84fbbc07d82770ec9d8cf5827db6d3418b815b4R183-R194) [[4]](diffhunk://#diff-7294911a29c887745c0c918ae84fbbc07d82770ec9d8cf5827db6d3418b815b4R249)

**Documentation and testing updates:**

* Expanded the README with clear instructions and explanations for installation scopes on Linux and macOS.
* Added tests to verify the `Scope` parameter for both installation and uninstallation, including validation of allowed values and default behaviors.
* Added usage example for system-wide uninstall to the `Uninstall-AITool` documentation.